### PR TITLE
Fix compilation on non-Android platforms

### DIFF
--- a/Runtime/Google.XR.Extensions.asmdef
+++ b/Runtime/Google.XR.Extensions.asmdef
@@ -12,7 +12,10 @@
         "GUID:e7613e527d035461da6942ba7283ee2d",
         "Unity.XR.CompositionLayers"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Android",
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": false,


### PR DESCRIPTION
This PR adjusts the Runtime asmdef to only include Android and the Editor. The adjustment fixes the compilation on non-Android platforms as reported in #7 